### PR TITLE
Add configurable escape sequence for template parameters

### DIFF
--- a/src/commands/create-function.spec.ts
+++ b/src/commands/create-function.spec.ts
@@ -3,7 +3,6 @@ import { existsSync, writeFileSync } from "fs";
 
 // utils
 import { emoji } from "../utils";
-import { BEGIN_ESCAPE, END_ESCAPE } from "./init.spec";
 
 const rootPath = "./.boilerplate";
 
@@ -16,7 +15,7 @@ const successMsg = (msg: string) => {
 };
 
 export const generateTemplateFunction = (name: string) => {
-  const content = `// usage in templates: ${BEGIN_ESCAPE} ${name}(arg1, arg2, ...) ${END_ESCAPE}
+  const content = `// usage in templates: ${global.BEGIN_SEQ} ${name}(arg1, arg2, ...) ${global.END_SEQ}
 module.exports = function (/* any args incl. local & global template args */) {
   // insert code here
 };

--- a/src/commands/create-function.spec.ts
+++ b/src/commands/create-function.spec.ts
@@ -3,6 +3,7 @@ import { existsSync, writeFileSync } from "fs";
 
 // utils
 import { emoji } from "../utils";
+import { BEGIN_ESCAPE, END_ESCAPE } from "./init.spec";
 
 const rootPath = "./.boilerplate";
 
@@ -15,7 +16,7 @@ const successMsg = (msg: string) => {
 };
 
 export const generateTemplateFunction = (name: string) => {
-  const content = `// usage in templates: <| ${name}(arg1, arg2, ...) |>
+  const content = `// usage in templates: ${BEGIN_ESCAPE} ${name}(arg1, arg2, ...) ${END_ESCAPE}
 module.exports = function (/* any args incl. local & global template args */) {
   // insert code here
 };

--- a/src/commands/init.spec.ts
+++ b/src/commands/init.spec.ts
@@ -1,3 +1,6 @@
+export const BEGIN_ESCAPE = "{%";
+export const END_ESCAPE = "%}";
+
 export const globalYaml = `# definition of 'filetype' arg
 filetype: # arg will be called using --filetype
   shorthand: ft # arg can be called using -ft instead of --filetype
@@ -15,11 +18,11 @@ name: # arg will be called using --name
   description: component name # used in help menu
 `;
 
-export const placeholderContent = `// <|timestamp()|>
-<|name|> = "hello world"
+export const placeholderContent = `// ${BEGIN_ESCAPE}timestamp()${END_ESCAPE}
+${BEGIN_ESCAPE}name${END_ESCAPE} = "hello world"
 `;
 
-export const templateFunctionContent = `// this is a template function - it can be invoked in templates using <| timestamp() |>
+export const templateFunctionContent = `// this is a template function - it can be invoked in templates using ${BEGIN_ESCAPE} timestamp() ${END_ESCAPE}
 // see here for more details: https://jordan-eckowitz.github.io/boil-cli-docs/how-it-works/#template-functions
 module.exports = function () {
   return Date.now();

--- a/src/commands/init.spec.ts
+++ b/src/commands/init.spec.ts
@@ -1,7 +1,17 @@
-export const BEGIN_ESCAPE = "{%";
-export const END_ESCAPE = "%}";
+global.BEGIN_SEQ = "<|";
+global.END_SEQ = "|>";
 
-export const globalYaml = `# definition of 'filetype' arg
+export const globalYaml = () => `# Escape sequences
+$begin:
+  shorthand: $b
+  description: Character sequence used to mark the beginning of a template parameter
+  default: "${global.BEGIN_SEQ}"
+$end:
+  shorthand: $e
+  description: Character sequence used to mark the end of a template parameter
+  default: "${global.END_SEQ}"
+
+# definition of 'filetype' arg
 filetype: # arg will be called using --filetype
   shorthand: ft # arg can be called using -ft instead of --filetype
   description: file type # used in help menu
@@ -18,11 +28,13 @@ name: # arg will be called using --name
   description: component name # used in help menu
 `;
 
-export const placeholderContent = `// ${BEGIN_ESCAPE}timestamp()${END_ESCAPE}
-${BEGIN_ESCAPE}name${END_ESCAPE} = "hello world"
+export const placeholderContent =
+  () => `// ${global.BEGIN_SEQ}timestamp()${global.END_SEQ}
+${global.BEGIN_SEQ}name${global.END_SEQ} = "hello world"
 `;
 
-export const templateFunctionContent = `// this is a template function - it can be invoked in templates using ${BEGIN_ESCAPE} timestamp() ${END_ESCAPE}
+export const templateFunctionContent =
+  () => `// this is a template function - it can be invoked in templates using ${global.BEGIN_SEQ} timestamp() ${global.END_SEQ}
 // see here for more details: https://jordan-eckowitz.github.io/boil-cli-docs/how-it-works/#template-functions
 module.exports = function () {
   return Date.now();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,8 +12,6 @@ import {
   placeholderContent,
   templateFunctionContent,
   readmeContent,
-  BEGIN_ESCAPE,
-  END_ESCAPE,
 } from "./init.spec";
 
 const rootPath = "./.boilerplate";
@@ -24,19 +22,19 @@ const generateFilesAndFolders = () => {
   // create readme
   writeFileSync(`${rootPath}/readme.txt`, readmeContent);
   // create global args yml file
-  writeFileSync(`${rootPath}/global.args.yml`, globalYaml);
+  writeFileSync(`${rootPath}/global.args.yml`, globalYaml());
   // create template function
-  writeFileSync(`${rootPath}/timestamp.js`, templateFunctionContent);
+  writeFileSync(`${rootPath}/timestamp.js`, templateFunctionContent());
   // create component directory (example template out-of-the-box)
   mkdirSync(`${rootPath}/component`);
   // create local args yml file
   writeFileSync(`${rootPath}/component/local.args.yml`, localYaml);
   // folder with template arg name
-  mkdirSync(`${rootPath}/component/${BEGIN_ESCAPE} name ${END_ESCAPE}`);
+  mkdirSync(`${rootPath}/component/${global.BEGIN_SEQ} name ${global.END_SEQ}`);
   // file with template arg name and filetype
   writeFileSync(
-    `${rootPath}/component/${BEGIN_ESCAPE} name ${END_ESCAPE}/${BEGIN_ESCAPE} name ${END_ESCAPE}.${BEGIN_ESCAPE} filetype ${END_ESCAPE}`,
-    placeholderContent
+    `${rootPath}/component/${global.BEGIN_SEQ} name ${global.END_SEQ}/${global.BEGIN_SEQ} name ${global.END_SEQ}.${global.BEGIN_SEQ} filetype ${global.END_SEQ}`,
+    placeholderContent()
   );
 };
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -43,9 +43,29 @@ export default class Init extends Command {
 
   static flags = {
     help: flags.help({ char: "h" }),
+    $begin: flags.string({
+      default: global.BEGIN_SEQ,
+      char: "b",
+      required: false,
+      description:
+        "Character sequence used to mark the beginning of a template parameter",
+    }),
+    $end: flags.string({
+      default: global.END_SEQ,
+      char: "e",
+      required: false,
+      description:
+        "Character sequence used to mark the end of a template parameter",
+    }),
   };
 
   async run() {
+    const { flags } = this.parse(Init);
+    const { $begin, $end } = flags;
+
+    global.BEGIN_SEQ = $begin;
+    global.END_SEQ = $end;
+
     if (boilerplateExists()) {
       this.log(
         printError(`looks like you already have a '.boilerplate' folder`)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,8 @@ import {
   placeholderContent,
   templateFunctionContent,
   readmeContent,
+  BEGIN_ESCAPE,
+  END_ESCAPE,
 } from "./init.spec";
 
 const rootPath = "./.boilerplate";
@@ -30,10 +32,10 @@ const generateFilesAndFolders = () => {
   // create local args yml file
   writeFileSync(`${rootPath}/component/local.args.yml`, localYaml);
   // folder with template arg name
-  mkdirSync(`${rootPath}/component/<| name |>`);
+  mkdirSync(`${rootPath}/component/${BEGIN_ESCAPE} name ${END_ESCAPE}`);
   // file with template arg name and filetype
   writeFileSync(
-    `${rootPath}/component/<| name |>/<| name |>.<| filetype |>`,
+    `${rootPath}/component/${BEGIN_ESCAPE} name ${END_ESCAPE}/${BEGIN_ESCAPE} name ${END_ESCAPE}.${BEGIN_ESCAPE} filetype ${END_ESCAPE}`,
     placeholderContent
   );
 };

--- a/src/commands/up.spec.ts
+++ b/src/commands/up.spec.ts
@@ -17,7 +17,6 @@ import { emoji, escapeRegExp } from "../utils";
 
 // types
 import { Arg, ArgsObject } from "../types";
-import { BEGIN_ESCAPE, END_ESCAPE } from "./init.spec";
 
 interface Args {
   [key: string]: string;
@@ -27,12 +26,11 @@ interface SplitArgs {
   [key: string]: string[];
 }
 
-const BEGIN_ESCAPE_E = escapeRegExp(BEGIN_ESCAPE);
-const END_ESCAPE_E = escapeRegExp(END_ESCAPE);
-
 const extractArg = (arg: string) => {
   const regex = new RegExp(
-    `(?<=${BEGIN_ESCAPE_E})(.*?)(?=${END_ESCAPE_E})`,
+    `(?<=${escapeRegExp(global.BEGIN_SEQ)})(.*?)(?=${escapeRegExp(
+      global.END_SEQ
+    )})`,
     "g"
   );
   return arg.match(regex);
@@ -47,12 +45,12 @@ const replaceArgs = (
   // remove whitespaces between '<|' and '|>' symbols, e.g. <|  WORD  |>  =>  <|WORD|>
   // const whitespaceLeftOfWord = /(?<=\<\|)\s+(?=[^\W])/g; // '<|   WORD'
   const whitespaceLeftOfWord = new RegExp(
-    `(?<=${BEGIN_ESCAPE_E})\\s+(?=[^\\W])`,
+    `(?<=${escapeRegExp(global.BEGIN_SEQ)})\\s+(?=[^\\W])`,
     "g"
   ); // '<|   WORD'
   // const whitespaceRightOfWord = /(?<=[^\W]|\))\s+(?=\|\>)/g; // 'WORD   |>'  OR  ')   |>' (for functions)
   const whitespaceRightOfWord = new RegExp(
-    `(?<=[^\\W]|\\))\\s+(?=${END_ESCAPE_E})`,
+    `(?<=[^\\W]|\\))\\s+(?=${escapeRegExp(global.END_SEQ)})`,
     "g"
   ); // 'WORD   |>'  OR  ')   |>' (for functions)
   const contentWithoutWhitespaces = content
@@ -63,7 +61,7 @@ const replaceArgs = (
   const newContent = Object.keys(argPlaceholderValues).reduce(
     (output, arg): string => {
       return output.replace(
-        `${BEGIN_ESCAPE}${arg}${END_ESCAPE}`,
+        `${global.BEGIN_SEQ}${arg}${global.END_SEQ}`,
         argPlaceholderValues[arg]
       );
     },

--- a/src/commands/up.spec.ts
+++ b/src/commands/up.spec.ts
@@ -139,6 +139,14 @@ export const localAndGlobalArgs = (template: string) => {
   return args;
 };
 
+export const getEscapeSequence = (template: string) => {
+  const args = localAndGlobalArgs(template) as any;
+  return {
+    begin: args.$begin.default ?? "<|",
+    end: args.$end.default ?? "|>",
+  };
+};
+
 export const userProvidedArgs = (template: string) => {
   const inputs = process.argv;
   const templateIndex = inputs.indexOf(template);

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -22,6 +22,7 @@ import {
   undefinedFunctions,
   extractFunctionInputArgs,
   getFunctionValues,
+  getEscapeSequence,
 } from "./up.spec";
 
 // types
@@ -76,6 +77,11 @@ run ${print("boil list")} to see all available boilerplate templates`,
         )
       );
     }
+
+    // 2.1 Get the configured/default escape sequence
+    const { begin, end } = getEscapeSequence(template);
+    global.BEGIN_SEQ = begin;
+    global.END_SEQ = end;
 
     // 3. Extract all template args (<|*|>) from the template directory
     const allArgs = getTemplateArgs(template);

--- a/src/types/declarations.d.ts
+++ b/src/types/declarations.d.ts
@@ -1,1 +1,8 @@
 declare module "read-data";
+
+declare namespace NodeJS {
+  interface Global {
+    BEGIN_SEQ: string;
+    END_SEQ: string;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { print, printError, bold, emoji, emojis } from "./logging";
 export { boilerplateExists, templateExists } from "./conflicts";
 export { templateArgsTable } from "./help";
+export { escapeRegExp } from "./regex";

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(text: string) {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+}

--- a/test/commands/up.test.ts
+++ b/test/commands/up.test.ts
@@ -5,7 +5,6 @@ import shell from "shelljs";
 
 // utils
 import { removeBoilerplateFolder, removeExampleTemplate } from "../utils";
-import { BEGIN_ESCAPE, END_ESCAPE } from "./../../src/commands/init.spec";
 
 /** For the `up` command `static strict = false` to allow any user inputs.
  *  This results in the `.command([])` method not always being able to parse the args.
@@ -43,12 +42,7 @@ describe("up", () => {
   test
     .stdout()
     .command(["create", "bad-example"])
-    .do(() =>
-      writeFileSync(
-        `./.boilerplate/bad-example/${BEGIN_ESCAPE}name${END_ESCAPE}.js`,
-        ""
-      )
-    )
+    .do(() => writeFileSync(`./.boilerplate/bad-example/<|name|>.js`, ""))
     .command(["up", "bad-example"])
     .it("check all template args have been defined", (ctx) => {
       expect(ctx.stdout).to.contain(
@@ -60,10 +54,7 @@ describe("up", () => {
     .stdout()
     .command(["create", "another-bad-example"])
     .do(() =>
-      writeFileSync(
-        `./.boilerplate/another-bad-example/${BEGIN_ESCAPE}example()${END_ESCAPE}.js`,
-        ""
-      )
+      writeFileSync(`./.boilerplate/another-bad-example/<|example()|>.js`, "")
     )
     .command(["up", "another-bad-example"])
     .it("check all functional args have been defined", (ctx) => {

--- a/test/commands/up.test.ts
+++ b/test/commands/up.test.ts
@@ -5,6 +5,7 @@ import shell from "shelljs";
 
 // utils
 import { removeBoilerplateFolder, removeExampleTemplate } from "../utils";
+import { BEGIN_ESCAPE, END_ESCAPE } from "./../../src/commands/init.spec";
 
 /** For the `up` command `static strict = false` to allow any user inputs.
  *  This results in the `.command([])` method not always being able to parse the args.
@@ -42,7 +43,12 @@ describe("up", () => {
   test
     .stdout()
     .command(["create", "bad-example"])
-    .do(() => writeFileSync("./.boilerplate/bad-example/<|name|>.js", ""))
+    .do(() =>
+      writeFileSync(
+        `./.boilerplate/bad-example/${BEGIN_ESCAPE}name${END_ESCAPE}.js`,
+        ""
+      )
+    )
     .command(["up", "bad-example"])
     .it("check all template args have been defined", (ctx) => {
       expect(ctx.stdout).to.contain(
@@ -54,7 +60,10 @@ describe("up", () => {
     .stdout()
     .command(["create", "another-bad-example"])
     .do(() =>
-      writeFileSync("./.boilerplate/another-bad-example/<|example()|>.js", "")
+      writeFileSync(
+        `./.boilerplate/another-bad-example/${BEGIN_ESCAPE}example()${END_ESCAPE}.js`,
+        ""
+      )
     )
     .command(["up", "another-bad-example"])
     .it("check all functional args have been defined", (ctx) => {


### PR DESCRIPTION
This is what I was able to hack together in a few hours:
- Instead of hardcoding the escape sequence (`<|` and `|>`) two global variables are used
- The `init` command takes two flags to configure the escape sequence during setup:
```bash
boil init -b "{%" -e "%}"
```
- The escape sequence values are saved in the generated `global.args.yaml`
- During the `up` command the escape sequence values are read from `global.args.yaml` and the global variables are updated

Closes #13 

